### PR TITLE
JOIN => Add USING statement

### DIFF
--- a/SuperSQL/lib/parser.php
+++ b/SuperSQL/lib/parser.php
@@ -161,12 +161,16 @@ class Parser
                 if ($i !== 0)
                     $sql .= ', ';
                 $sql .= '`' . $val . '`';
-                if ($t)
+                if ($alias)
                     $sql .= ' AS `' . $alias . '`';
             }
             return $sql;
         } else {
-            return '`' . $table . '`';
+            $alias = self::getType($table);
+            $sql = '`' . $table . '`';
+            if ($alias)
+                $sql .= ' AS `' . $alias . '`';
+            return $sql;
         }
     }
     static function value($type, $value)

--- a/SuperSQL/lib/parser.php
+++ b/SuperSQL/lib/parser.php
@@ -364,7 +364,15 @@ class Parser
                     break;
             }
             
-            $sql .= ' JOIN `' . $key . '` ON ';
+            $sql .= ' JOIN `' . $key . '` ';
+            
+            if(!$raw && count($val) == 1 && strpos(array_values($val)[0],'.') === false) {
+                $sql .= 'USING (`' . array_values($val)[0] . '`) ';
+                return;
+            }
+            
+            $sql .= 'ON ';
+
             if ($raw) {
                 $sql .= $val;
             } else {


### PR DESCRIPTION
In PHP 7.1.15 if you do something like :
SQL : 
SELECT
tbl_a.col_a, tbl_a.col_b,
tbl_b.col_ba, tbl_b.col_bb
FROM tbl_a
LEFT JOIN tbl_b ON (tbl_a.ID = tbl_b.ID)

results will be nulled for all tbl_b columns

with USING this problem is solved.

it works but i don't like my conditional : strpos(array_values($val)[0],'.')